### PR TITLE
chore: Simplify CircleCI config by removing `dotnet-node-executor`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,6 @@ executors:
   dotnet-executor:
     docker:
       - image: mcr.microsoft.com/dotnet/sdk:8.0
-  dotnet-node-executor:
-    docker:
-      - image: dotnetimages/microsoft-dotnet-core-sdk-nodejs:8.0_16.x
 
 jobs:
   check-commit:
@@ -35,12 +32,24 @@ jobs:
       - run: dotnet restore
       - run: dotnet build --no-restore -c Release
   pack:
-    executor: dotnet-node-executor
+    executor: dotnet-executor
     steps:
       - checkout:
           path: .
           fetch-depth: 0
       - run: dotnet restore
+      - run:
+          name: Install Node.js
+          command: |
+            apt-get update \
+            && apt-get install -y ca-certificates curl gnupg \
+            && mkdir -p /etc/apt/keyrings \
+            && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+                 | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+            && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
+                 > /etc/apt/sources.list.d/nodesource.list \
+            && apt-get update \
+            && apt-get install -y nodejs
       - restore_cache:
           keys:
             - node-deps-{{ checksum "SemanticRelease.Abstractions.sln" }}


### PR DESCRIPTION
- Updated the `pack` job to use `dotnet-executor`.
- Removed `dotnet-node-executor` and replaced it with manual Node.js installation in the `pack` job.
- Streamlined Docker image usage for CI pipeline.